### PR TITLE
Change symfony/cache and psr/cache requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,17 +21,17 @@
         "guzzlehttp/guzzle": "^6.5|^7.0",
         "psr/cache": "^1.0",
         "kevinrob/guzzle-cache-middleware": "^3.3",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2.0|^3.0",
         "sop/asn1": "^4.1",
         "sop/x501": "^0.6.1",
         "sop/crypto-types": "^0.3.0",
         "sop/crypto-bridge": "^0.3.1",
         "sop/crypto-encoding": "^0.3.0",
-        "ext-sodium": "*"
+        "ext-sodium": "*",
+        "symfony/cache": "^5.2|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "symfony/cache": "^5.2",
         "phpstan/phpstan": "^0.12.64",
         "symfony/var-dumper": "^5.2",
         "symfony/console": "^5.2",


### PR DESCRIPTION
This commit:
- Moves symfony/cache from "require-dev" to "require" since src/Cache/FileCacheProvider.php depends on it.
- Implements support for symfony/cache ^6.0, no changes other than updating the version requirements were required.
- Implements support for psr/cache ^2.0 and ^3.0, no changes other than updating the version requirements were necessary since this library does not implement any of the interfaces in psr/cache.