### PR TITLE
Add Backup flags specified in W3C Level 3 draft

### DIFF
--- a/src/Attestation/AuthenticatorData.php
+++ b/src/Attestation/AuthenticatorData.php
@@ -44,7 +44,7 @@ final class AuthenticatorData
      /**
      * Backup State (BS).
      */
-    private const FLAG_ED = 1 << 4;
+    private const FLAG_BS = 1 << 4;
 
     /**
      * SHA-256 hash of the RP ID associated with the credential.

--- a/src/Attestation/AuthenticatorData.php
+++ b/src/Attestation/AuthenticatorData.php
@@ -35,6 +35,16 @@ final class AuthenticatorData
      * Extension data included (ED).
      */
     private const FLAG_ED = 1 << 7;
+    
+     /**
+     * Backup Eligibility (BE).
+     */
+    private const FLAG_BE = 1 << 3;
+    
+     /**
+     * Backup State (BS).
+     */
+    private const FLAG_ED = 1 << 4;
 
     /**
      * SHA-256 hash of the RP ID associated with the credential.
@@ -149,6 +159,16 @@ final class AuthenticatorData
     public function isUserVerified(): bool
     {
         return ($this->flags & self::FLAG_UV) !== 0;
+    }
+    
+    public function isBackupEligable(): bool
+    {
+        return ($this->flags & self::FLAG_BE) !== 0;
+    }
+
+    public function isBackedUp(): bool
+    {
+        return ($this->flags & self::FLAG_BS) !== 0;
     }
 
     public function hasAttestedCredentialData(): bool


### PR DESCRIPTION
I know this is probably a bit to early since the W3C Level 3 is still a draft and not final yet, but i thought i might add this PR in case it is needed in the future?

Basicly W3C Level 3 (Draft) States to also store on registration if the BE/BS flags are set and ask the user to take actions according to the value of it (see this [requirement](https://w3c.github.io/webauthn/#sctn-registering-a-new-credential) and the new [table](https://w3c.github.io/webauthn/#authdata-flags-be)