### PR TITLE
Fix EdDSA keys / improve YubiKey support

### DIFF
--- a/src/Crypto/CoseKey.php
+++ b/src/Crypto/CoseKey.php
@@ -80,6 +80,12 @@ abstract class CoseKey implements CoseKeyInterface
             throw new DataValidationException('Failed to decode CBOR encoded COSE key'); // TODO: change exceptions
         }
 
+        // Replace textual kty's with their numeric counterparts
+        if ($data->get(self::COSE_KEY_PARAM_KTY) === 'OKP')
+            $data->set(self::COSE_KEY_PARAM_KTY, 1);
+        elseif ($data->get(self::COSE_KEY_PARAM_KTY) === 'EC2')
+            $data->set(self::COSE_KEY_PARAM_KTY, 2);
+
         DataValidator::checkMap(
             $data,
             [

--- a/src/Crypto/OkpKey.php
+++ b/src/Crypto/OkpKey.php
@@ -113,6 +113,16 @@ class OkpKey extends CoseKey
 
     public static function fromCborData(CborMap $data): OkpKey
     {
+        // Translate literal curves to their numeric constant
+        if ($data->get(self::KTP_CRV) === 'X25519')
+            $data->set(self::KTP_CRV, 4);
+        elseif ($data->get(self::KTP_CRV) === 'X448')
+            $data->set(self::KTP_CRV, 5);
+        elseif ($data->get(self::KTP_CRV) === 'Ed25519')
+            $data->set(self::KTP_CRV, 6);
+        elseif ($data->get(self::KTP_CRV) === 'Ed448')
+            $data->set(self::KTP_CRV, 7);
+
         // Note: leading zeroes in X and Y coordinates are preserved in CBOR
         // See RFC8152 13.1.1. Double Coordinate Curves
         DataValidator::checkMap(


### PR DESCRIPTION
This PR fixes two issues we faced with YubiKeys. 

First issue: `kty` and `crv` can either be `int` or `tstr`according to the RFC, where the string version should be one of the constants (like `OKP` or `Ed25519`). However, this library parses only the int version. This PR adds support for the string constants related to elliptic curves. There are likely more places where string constants are applicable, but the provided fixes are at least enough to get YubiKey working. Example input of such a key: `{1: 'OKP', 3: -8, -1: 'Ed25519'}`. 

Second issue: some keys generate broken keys during registration (two errors: map length is wrong, and public key component `x` is bytearray instead of bytestring). See [this issue](https://github.com/web-auth/webauthn-framework/issues/436) for a more in-depth discussion. While this is technically not a fault in this library, this PR adds a workaround that detects and fixes those broken keys. Other webauthn libraries use [such workarounds](https://github.com/web-auth/webauthn-framework/blob/4.8.x/src/webauthn/src/AuthenticatorDataLoader.php#L82C22-L82C42) as well. 